### PR TITLE
Fix: replace deprecated model with gemini-2.5-flash-image

### DIFF
--- a/nano_banano.py
+++ b/nano_banano.py
@@ -267,7 +267,7 @@ class ComfyUI_NanoBanana:
                 try:
                     # Generate content using the working v6 approach
                     response = client.models.generate_content(
-                        model="gemini-2.0-flash-exp-image-generation",
+                        model="gemini-2.5-flash-image", 
                         contents=content_parts,
                         config=generation_config
                     )
@@ -415,4 +415,5 @@ NODE_CLASS_MAPPINGS = {
 
 NODE_DISPLAY_NAME_MAPPINGS = {
     "ComfyUI_NanoBanana": "Nano Banana (Gemini 2.5 Flash Image)",
+
 }


### PR DESCRIPTION
The previous model `gemini-2.0-flash-exp-image-generation` is deprecated and no longer available for API version v1beta. Updated to `gemini-2.5-flash-image` which supports image generation on the latest Gemini 2.5 API.